### PR TITLE
Fix immediate error in multi-core learning

### DIFF
--- a/Apptainer.gofai.multicore.learn
+++ b/Apptainer.gofai.multicore.learn
@@ -94,7 +94,9 @@ Stage: run
     shift 2  # Forget first two arguments.
     PROBLEM_FILES=("$@")  # All remaining arguments are problem files.
 
-    python3 /learn.py "$DOMAIN_FILE" "${PROBLEM_FILES[@]}" --domain_knowledge_file "$DOMAIN_KNOWLEDGE_FILE" --cpus 32 --total_time_limit 259200 --total_memory_limit 90000
+    num_cores=$(nproc)
+
+    python3 /learn.py "$DOMAIN_FILE" "${PROBLEM_FILES[@]}" --domain_knowledge_file "$DOMAIN_KNOWLEDGE_FILE" --cpus $num_cores --total_time_limit 259200 --total_memory_limit 90000
 
 %labels
 Name        GOFAI


### PR DESCRIPTION
The previous version hard-coded the number of cores to 32, which apparently are not available during testing. The fix checks how many cores are available and uses all of them.