### PR TITLE
Use legacy repository for Ubuntu kinetic

### DIFF
--- a/Apptainer.gofai.learn
+++ b/Apptainer.gofai.learn
@@ -9,6 +9,7 @@ Stage: build
     learning/yap
 
 %post
+    sed -i 's|http://\(.*\).ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
     apt-get update
     apt-get -y install --no-install-recommends cmake make g++ python3 automake pkg-config libgmp10 libgmp-dev libreadline-dev  libsqlite3-dev sqlite3
 
@@ -78,6 +79,7 @@ Stage: run
 
 
 %post
+    sed -i 's|http://\(.*\).ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
     apt-get update
     apt-get -y install --no-install-recommends python3 python3-pip
     apt-get clean

--- a/Apptainer.gofai.plan
+++ b/Apptainer.gofai.plan
@@ -7,6 +7,7 @@ Stage: build
     fd-partial-grounding
 
 %post
+    sed -i 's|http://\(.*\).ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
     apt-get update
     apt-get -y install --no-install-recommends cmake make g++ python3
 
@@ -35,6 +36,7 @@ Stage: run
     /fd-partial-grounding/driver
 
 %post
+    sed -i 's|http://\(.*\).ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
     apt-get update
     apt-get -y install --no-install-recommends python3 python3-pip
     apt-get clean


### PR DESCRIPTION
The Apptainer file builds on Ubuntu kinetic, which reached its end of life and is no longer available in the standard Ubuntu repository. The change let's the script use the legacy repository (provided by Ubuntu) instead.